### PR TITLE
Fix crash on setblock

### DIFF
--- a/src/main/java/net/kyrptonaught/customportalapi/CustomPortalBlock.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/CustomPortalBlock.java
@@ -128,6 +128,9 @@ public class CustomPortalBlock extends Block {
             if (!CustomPortalsMod.isInstanceOfCustomPortal(world, pos.offset(axis, -1)))
                 return world.getBlockState(pos.offset(axis, -1)).getBlock();
         }
+        if(pos.getY() < 0){
+            return null;
+        }
         return getPortalBase(world, pos.down());
     }
 }


### PR DESCRIPTION
There was no issue made about this, but before these changes, the game would crash on /setblock (For example, /setblock ~ ~ ~ the_aether:blue_portal would crash when there was no glowstone below it). Prior to this update, a StackOverflowError would occur. Now, getPortalBase() will stop looping when the Y value of the block being searched is below zero, since there are no more blocks below and thus no reason to continue looping into the void.