### PR TITLE
Configure sodium as optional dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,10 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation('maven.modrinth:sodium:mc1.19.4-0.4.10') { exclude group: "net.fabricmc.fabric-api" }
+	// optional dependency
+	modCompileOnly('maven.modrinth:sodium:mc1.19.4-0.4.10') { exclude group: "net.fabricmc.fabric-api" }
 }
+
 processResources {
 	inputs.property "version", project.version
 

--- a/src/main/java/net/kyrptonaught/customportalapi/mixin/CustomPortalApiMixinPlugin.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/mixin/CustomPortalApiMixinPlugin.java
@@ -1,0 +1,49 @@
+package net.kyrptonaught.customportalapi.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class CustomPortalApiMixinPlugin implements IMixinConfigPlugin {
+
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.equals("net.kyrptonaught.customportalapi.mixin.client.SodiumBlendingFix"))
+            return FabricLoader.getInstance().isModLoaded("sodium");
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/src/main/resources/customportalapi.mixins.json
+++ b/src/main/resources/customportalapi.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "package": "net.kyrptonaught.customportalapi.mixin",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "net.kyrptonaught.customportalapi.mixin.CustomPortalApiMixinPlugin",
   "mixins": [
     "EntityMixin",
     "ServerPlayerMixin",


### PR DESCRIPTION
 Uses MixinPlugin to determine whether to load the optional compatibility mixin.